### PR TITLE
Fixes for Opencast 6

### DIFF
--- a/opencastcsvschedule/__init__.py
+++ b/opencastcsvschedule/__init__.py
@@ -125,7 +125,7 @@ def schedule_events(input_fobj, base_url, user, password):
             response.raise_for_status()
         except Exception as e:
             logging.error('Error posting event')
-            logging.error('Row was: %s', ','.join(row))
+            logging.error('Row was: %r', row)
             logging.exception(e)
 
 

--- a/opencastcsvschedule/__init__.py
+++ b/opencastcsvschedule/__init__.py
@@ -158,10 +158,9 @@ def oc_metadata(row):
 
 def oc_sched(row):
     """Create opencast schedule for an event"""
-    duration = _parse_date(row["stopTime"]) - _parse_date(row["startTime"])
     sched = {"agent_id": row["location"],
              "start": row["startTime"],
-             "duration": 1000 * int(duration.total_seconds()),
+             "end": row["stopTime"],
              "inputs": ["default"]}
     return sched
 


### PR DESCRIPTION
This PR fixes a small logging bug and fixes compatibility with the Opencast v1.1 API which, although it claims one can specify start and duration only, seems to 500 when one does.