### PR TITLE
configure inputs explicitly

### DIFF
--- a/opencastcsvschedule/__init__.py
+++ b/opencastcsvschedule/__init__.py
@@ -158,10 +158,12 @@ def oc_metadata(row):
 
 def oc_sched(row):
     """Create opencast schedule for an event"""
-    sched = {"agent_id": row["location"],
-             "start": row["startTime"],
-             "end": row["stopTime"],
-             "inputs": ["default"]}
+    sched = {
+        "agent_id": row["location"],
+        "start": row["startTime"],
+        "end": row["stopTime"],
+        "inputs": ["camera", "screen", "AudioSource"],
+    }
     return sched
 
 


### PR DESCRIPTION
Empirically, setting "default" as the imputs field no longer sets all the default inputs. Explicitly configure them in the API call.